### PR TITLE
accepting wrong characters

### DIFF
--- a/components/typing-area.tsx
+++ b/components/typing-area.tsx
@@ -191,12 +191,13 @@ export function TypingArea({
       const expectedChar = targetText[cursorPosition];
       const isCorrect = e.key === expectedChar;
       
+      // ? No matter if the character is correct or not, it should be inserted
+      const newText = currentValue.slice(0, cursorPosition) + e.key + currentValue.slice(cursorPosition);
+      onType(newText);
+      setCursorPosition(cursorPosition + 1);
+
       if (isCorrect) {
         if (settings.soundEffects) playKeyPress();
-        const newText = currentValue.slice(0, cursorPosition) + e.key + currentValue.slice(cursorPosition);
-        onType(newText);
-        setCursorPosition(cursorPosition + 1);
-
         // Check if this was the last character
         if (newText === targetText) {
           calculateAndUpdateStats();


### PR DESCRIPTION
This PR handles issue #5 

I just had to add the character to the `newText` variable, no matter if the character was correct or not, the color and rest of the things were already handled.

https://github.com/user-attachments/assets/8115de0b-e950-40ec-a8d3-d7c4970066c5

